### PR TITLE
Use the watchlist to select the new chat to be notified

### DIFF
--- a/app/javascript/components/notifyer.js
+++ b/app/javascript/components/notifyer.js
@@ -47,7 +47,7 @@ class Notifyer {
       const newChat = Chat.appendPrivateChat(data.chat_room_id, data.chat_room_name);
       // if (data.chat_room_id === App.active_room_id) return;
     // Notify the new Chat
-      this.notify(newChat)
+      this.notify(this.watchList[data.chat_room_id])
     }
   }
 }


### PR DESCRIPTION
Work on Notifyer logic. Selecting the chat based on the watchList instead of latest appended element. Preventing notifying bug on unwatched private chats. 